### PR TITLE
BT-651 forbidden on E3

### DIFF
--- a/fields/national-rules.json
+++ b/fields/national-rules.json
@@ -1457,5 +1457,22 @@
         }
       ]
     }
+  },
+  {
+    "id": "BT-651-Lot",
+    "forbidden": {
+      "constraints": [
+        {
+          "noticeTypes": [
+            "E3"
+          ],
+          "value": true,
+          "severity": "ERROR"
+        }
+      ]
+    },
+    "mandatory": {
+      "constraints": []
+    }
   }
 ]

--- a/schematrons/generated/FI-Validation-E3.sch
+++ b/schematrons/generated/FI-Validation-E3.sch
@@ -70,6 +70,9 @@
 <assert id="FI-E3-BT-65-Lot-1" role="ERROR" test="count(cbc:SubcontractingConditionsCode) = 0">rule|text|FI-E3-BT-65-Lot-1</assert>
 <assert id="FI-E3-BT-729-Lot-1" role="ERROR" test="count(cbc:MaximumPercent) = 0">rule|text|FI-E3-BT-729-Lot-1</assert>
 </rule>
+<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:TenderSubcontractingRequirements[$noticeSubType = 'E3']">
+<assert id="FI-E3-BT-651-Lot-1" role="ERROR" test="count(efbc:TenderSubcontractingRequirementsCode) = 0">rule|text|FI-E3-BT-651-Lot-1</assert>
+</rule>
 <rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:EconomicOperatorShortList[$noticeSubType = 'E3']">
 <assert id="FI-E3-BT-661-Lot-1" role="ERROR" test="count(cbc:LimitationDescription) &gt; 0 or ../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'open' or ../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'oth-single' or ../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'neg-wo-call'">rule|text|FI-E3-BT-661-Lot-1</assert>
 <assert id="FI-E3-BT-661-Lot-2" role="ERROR" test="count(cbc:LimitationDescription) = 0 or not(../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'open' or ../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'oth-single' or ../../../cac:TenderingProcess/cbc:ProcedureCode/normalize-space(text()) = 'neg-wo-call')">rule|text|FI-E3-BT-661-Lot-2</assert>

--- a/translations/hilma_rule_en.xml
+++ b/translations/hilma_rule_en.xml
@@ -279,6 +279,7 @@
     <entry key="rule|text|FI-E3-FI-11-1">FI-E3-FI-11-1 - is mandatory.</entry>
     <entry key="rule|text|FI-E3-FI-20-1">FI-E3-FI-20-1 - is mandatory.</entry>
     <entry key="rule|text|FI-E3-FI-30-1">FI-E3-FI-30-1 - is mandatory.</entry>
+    <entry key="rule|text|FI-E3-BT-651-1">'Subcontracting Tender Indication' (BT-651-Lot) - is not allowed.</entry>
     <!-- E4 -->
     <entry key="rule|text|FI-E4-BT-105-Procedure-1">FI-E4-BT-105-Procedure-1 - is mandatory.</entry>
     <entry key="rule|text|FI-E4-BT-10-Procedure-Buyer-1">count(cac:ContractingActivity/cbc:ActivityTypeCode[@listName='authority-activity']) &gt; 0 or not(cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-legal-type']/normalize-space(text()) = ('body-pl','body-pl-cga','body-pl-la','body-pl-ra','cga','def-cont','eu-ins-bod-ag','grp-p-aut','int-org','la','org-sub','org-sub-cga','org-sub-la','org-sub-ra','ra'))</entry>

--- a/translations/hilma_rule_fi.xml
+++ b/translations/hilma_rule_fi.xml
@@ -279,6 +279,7 @@
     <entry key="rule|text|FI-E3-FI-11-1">FI-E3-FI-11-1 - on pakollinen.</entry>
     <entry key="rule|text|FI-E3-FI-20-1">FI-E3-FI-20-1 - on pakollinen.</entry>
     <entry key="rule|text|FI-E3-FI-30-1">FI-E3-FI-30-1 - on pakollinen.</entry>
+    <entry key="rule|text|FI-E3-BT-651-1">'Subcontracting Tender Indication' (BT-651-Lot) - ei ole sallittu.</entry>
     <!-- E4 -->
     <entry key="rule|text|FI-E4-BT-105-Procedure-1">FI-E4-BT-105-Procedure-1 - on pakollinen.</entry>
     <entry key="rule|text|FI-E4-BT-10-Procedure-Buyer-1">count(cac:ContractingActivity/cbc:ActivityTypeCode[@listName='authority-activity']) &gt; 0 or not(cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-legal-type']/normalize-space(text()) = ('body-pl','body-pl-cga','body-pl-la','body-pl-ra','cga','def-cont','eu-ins-bod-ag','grp-p-aut','int-org','la','org-sub','org-sub-cga','org-sub-la','org-sub-ra','ra'))</entry>


### PR DESCRIPTION
Update national-rules to include BT-651 forbidden on E3 along with updated schematron and translation files.